### PR TITLE
Protect AI integrations and teacher scheduling updates

### DIFF
--- a/src/components/ChatPanel.jsx
+++ b/src/components/ChatPanel.jsx
@@ -3,6 +3,7 @@ import { Send, Bot, ChevronUp, Trash2 } from 'lucide-react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useAuth } from '../contexts/AuthContext';
 import { useTextToSpeech } from '../hooks/useTextToSpeech';
+import { callSecureApi } from '../lib/apiClient';
 
 // ZMIANA: Importujemy react-markdown i plugin GFM
 import ReactMarkdown from 'react-markdown';
@@ -70,12 +71,6 @@ const ChatPanel = ({ isMobile = false }) => {
     if (isLoading) return t('chatWaitMessage');
     setIsLoading(true);
 
-    const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
-    if (!apiKey) {
-      console.error('Missing Gemini API key');
-      return t('chatConfigError');
-    }
-
     const contextPrompt = `
       Conversation context:
       - You are an AI mentor on an educational platform for learning mathematics.
@@ -93,23 +88,17 @@ const ChatPanel = ({ isMobile = false }) => {
       4. In ${currentLanguage === 'pl' ? 'Polish' : 'English'} language.
     `;
 
-    const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
-    const payload = {
-      contents: [{
-        role: "user",
-        parts: [{
-          text: contextPrompt
-        }]
-      }]
-    };
-
     try {
-      const response = await fetch(apiUrl, {
+      const response = await callSecureApi('/ai/chat', {
         method: 'POST',
-        headers: { 
+        headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify(payload)
+        body: JSON.stringify({
+          prompt: contextPrompt,
+          locale: currentLanguage,
+          history: messages.map(m => ({ role: m.type, content: m.content }))
+        })
       });
 
       if (!response.ok) {
@@ -118,19 +107,17 @@ const ChatPanel = ({ isMobile = false }) => {
       }
 
       const result = await response.json();
-      
-      if (!result.candidates || !result.candidates[0]?.content?.parts) {
-        throw new Error('Invalid API response structure');
+
+      if (!result || typeof result.reply !== 'string') {
+        throw new Error('Invalid proxy response structure');
       }
 
-      const text = result.candidates[0].content.parts[0]?.text;
-      if (!text) {
-        throw new Error('No text in API response');
-      }
-
-      return text;
+      return result.reply;
     } catch (error) {
       console.error('Gemini API Error:', error);
+      if (typeof error?.message === 'string' && error.message.includes('Secure proxy URL')) {
+        return t('chatConfigError');
+      }
       return t('chatErrorMessage');
     } finally {
       setIsLoading(false);

--- a/src/components/TeacherDashboard/AvailabilityWidget.jsx
+++ b/src/components/TeacherDashboard/AvailabilityWidget.jsx
@@ -63,7 +63,12 @@ const AvailabilityWidget = () => {
   // Handle form submission
   const handleSubmit = async (e) => {
     e.preventDefault();
-    
+
+    if (!user) {
+      console.warn('Attempted to modify availability without an authenticated user.');
+      return;
+    }
+
     // Validate time range
     if (formData.startTime >= formData.endTime) {
       setToast({
@@ -84,7 +89,8 @@ const AvailabilityWidget = () => {
             start_time: formData.startTime,
             end_time: formData.endTime
           })
-          .eq('id', editingSlot.id);
+          .eq('id', editingSlot.id)
+          .eq('teacher_id', user.id);
 
         if (error) throw error;
         
@@ -136,6 +142,11 @@ const AvailabilityWidget = () => {
 
   // Handle slot deletion
   const handleDelete = async (slotId) => {
+    if (!user) {
+      console.warn('Attempted to delete availability without an authenticated user.');
+      return;
+    }
+
     if (!confirm('Czy na pewno chcesz usunąć ten slot dostępności?')) {
       return;
     }
@@ -144,7 +155,8 @@ const AvailabilityWidget = () => {
       const { error } = await supabase
         .from('availability_slots')
         .delete()
-        .eq('id', slotId);
+        .eq('id', slotId)
+        .eq('teacher_id', user.id);
 
       if (error) throw error;
       

--- a/src/components/TeacherDashboard/PendingRequestsWidget.jsx
+++ b/src/components/TeacherDashboard/PendingRequestsWidget.jsx
@@ -97,11 +97,17 @@ const PendingRequestsWidget = () => {
 
   // Handle confirm/reject actions
   const handleConfirm = async (eventId) => {
+    if (!user) {
+      console.warn('Attempted to confirm event without authenticated user.');
+      return;
+    }
+
     try {
       const { error } = await supabase
         .from('calendar_events')
         .update({ status: 'confirmed' })
-        .eq('id', eventId);
+        .eq('id', eventId)
+        .eq('teacher_id', user.id);
 
       if (error) throw error;
 
@@ -125,11 +131,17 @@ const PendingRequestsWidget = () => {
   };
 
   const handleReject = async (eventId) => {
+    if (!user) {
+      console.warn('Attempted to reject event without authenticated user.');
+      return;
+    }
+
     try {
       const { error } = await supabase
         .from('calendar_events')
         .update({ status: 'cancelled' })
-        .eq('id', eventId);
+        .eq('id', eventId)
+        .eq('teacher_id', user.id);
 
       if (error) throw error;
 

--- a/src/hooks/useTextToSpeech.js
+++ b/src/hooks/useTextToSpeech.js
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useSettings } from '../contexts/SettingsContext';
+import { callSecureApi } from '../lib/apiClient';
 
 // Module-level lock to prevent multiple simultaneous speech requests
 let isCurrentlySpeaking = false;
@@ -27,11 +28,6 @@ export const useTextToSpeech = () => {
         isCurrentlySpeaking = false;
       }, 15000);
 
-      const apiKey = import.meta.env.VITE_ELEVENLABS_API_KEY;
-      if (!apiKey) {
-        throw new Error('ElevenLabs API key not found. Text-to-speech disabled.');
-      }
-
       // Format mathematical expressions for speech
       const formattedText = text
         // First, clean HTML tags
@@ -55,21 +51,17 @@ export const useTextToSpeech = () => {
         throw new Error("Cleaned text is empty.");
       }
 
-      const response = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${settings.textToSpeechVoice}`, {
+      const response = await callSecureApi('/tts/speak', {
         method: 'POST',
         headers: {
           'Accept': 'audio/mpeg',
-          'Content-Type': 'application/json',
-          'xi-api-key': apiKey
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify({
           text: formattedText,
-          model_id: "eleven_multilingual_v2",
-          voice_settings: {
-            stability: 0.5,
-            similarity_boost: 0.5,
-            speed: settings.textToSpeechSpeed || 1.0
-          }
+          voice: settings.textToSpeechVoice,
+          model: 'eleven_multilingual_v2',
+          speed: settings.textToSpeechSpeed || 1.0
         })
       });
 

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -1,0 +1,29 @@
+const normalizePath = (path) => {
+  if (!path) {
+    return '';
+  }
+
+  return path.startsWith('/') ? path : `/${path}`;
+};
+
+export const callSecureApi = (path, options = {}) => {
+  const baseUrl = import.meta.env.VITE_SECURE_PROXY_URL;
+
+  if (!baseUrl) {
+    throw new Error('Secure proxy URL (VITE_SECURE_PROXY_URL) is not configured.');
+  }
+
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+  const url = `${normalizedBase}${normalizePath(path)}`;
+
+  const fetchOptions = {
+    credentials: 'include',
+    ...options,
+    headers: {
+      'X-Requested-With': 'edu-future-app',
+      ...(options.headers || {})
+    }
+  };
+
+  return fetch(url, fetchOptions);
+};

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -8,17 +8,27 @@ if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase environment variables');
 }
 
-console.log('Initializing Supabase client');
+const createEphemeralStorage = () => {
+  const store = new Map();
+
+  return {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    }
+  };
+};
+
+const storage = typeof window !== 'undefined' ? createEphemeralStorage() : undefined;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
     autoRefreshToken: true,
-    persistSession: true,
+    persistSession: false,
     detectSessionInUrl: true,
-    storageKey: 'edu-future-auth-token',
-    storage: window.localStorage
+    storage
   }
 });
-
-// Debug: Log when Supabase client is initialized
-console.log('Supabase client initialized');

--- a/src/test.VoiceAssistantTest.jsx
+++ b/src/test.VoiceAssistantTest.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { callSecureApi } from './lib/apiClient';
 
 const VoiceAssistantTest = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -11,28 +12,18 @@ const VoiceAssistantTest = () => {
     setSuccess(null);
 
     try {
-      const apiKey = import.meta.env.VITE_ELEVENLABS_API_KEY;
-      if (!apiKey) {
-        throw new Error("Nie znaleziono klucza API dla ElevenLabs. Sprawdź plik .env");
-      }
-
       console.log("Rozpoczynam generowanie audio...");
 
-      // Używamy fetch API zamiast biblioteki ElevenLabs
-      const response = await fetch('https://api.elevenlabs.io/v1/text-to-speech/ZT9u07TYPVl83ejeLakq', {
+      const response = await callSecureApi('/tts/speak', {
         method: 'POST',
         headers: {
           'Accept': 'audio/mpeg',
-          'Content-Type': 'application/json',
-          'xi-api-key': apiKey
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify({
-          text: "Witaj w Edu Future! Czas na naukę matematyki.",
-          model_id: "eleven_multilingual_v2",
-          voice_settings: {
-            stability: 0.5,
-            similarity_boost: 0.5
-          }
+          text: 'Witaj w Edu Future! Czas na naukę matematyki.',
+          voice: 'ZT9u07TYPVl83ejeLakq',
+          model: 'eleven_multilingual_v2'
         })
       });
 


### PR DESCRIPTION
## Summary
- add a shared secure proxy helper and route chat and text-to-speech requests through it instead of exposing API keys in the browser
- configure the Supabase client to avoid persisting auth tokens in localStorage
- scope teacher availability edits and lesson request updates to the authenticated teacher

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fbf5df7fc883219e8e83387b1dc349